### PR TITLE
[Feature] Add personal config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,33 @@
   git clone git@github.com:kucho/dotfiles.git ~/dotfiles
   ```
 
-2. Install the configuration files you need/want:
+2. Setup personal credentials:
+  ```bash
+  # git/.git_config/.personal/.gitconfig-local
+  [user]
+    name = My Username
+    email = My Email
+    signingkey = My Signingkey
+  ```
+
+  - <details>
+      <summary>For WSL2 only</summary>
+
+      ```bash
+      # wsl2/.config/.gpg/.gitconfig-os-specific-local
+      [gpg "ssh"]
+        # replace MyUser for your machine user
+        program = "/mnt/c/Users/MyUser/AppData/Local/1Password/app/8/op-ssh-sign-wsl"
+      ```
+    </details>
+
+  - Finally run:
+    ```bash
+    # This will untrack our personal credentials
+    ./utils/00-ignore-personal-config.zsh
+    ```
+
+3. Install the configuration files you need/want:
   ```bash
   cd ~/dotfiles
   stow zsh
@@ -18,7 +44,24 @@
   stow osx
   ```
 
-3. Edit/Replace/Create new config files and restow them:
+4. Edit/Replace/Create new config files and restow them:
   ```bash
   stow -R zsh # the folder that contains the new config file
   ```
+
+## Known issues
+
+<details>
+  <summary><b>WSL2</b></summary>
+
+
+- If you're getting `"warning: Empty last update token."` it is due to `fsmonitor` is `true` at the `git/.gitconfig` file. There is two solucions for that
+    - The not recommended one is to simple set it as `false`
+    - The second one is to upgrade the `git version` because it was solved at `2.36.1` so to upgrade it is as simple as:
+    ```bash
+    git --version # it must be >= 2.36.1
+    # if not let's upgrade git
+    sudo add-apt-repository ppa:git-core/ppa
+    sudo apt update && sudo apt upgrade -y
+    ```
+</details>

--- a/git/.git_config/.personal/.gitconfig-local
+++ b/git/.git_config/.personal/.gitconfig-local
@@ -1,0 +1,4 @@
+[user]
+	name = My Username
+	email = My Email
+	signingkey = My Signingkey

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -9,6 +9,7 @@
 [gpg]
 	format = ssh
 [include]
+	path = ~/.git_config/.personal/.gitconfig-local
 	path = ~/.gitconfig-os-specific
 [init]
 	defaultBranch = main
@@ -21,7 +22,3 @@
 [rerere]
 	autoUpdate = true
 	enabled = true
-[user]
-	email = victor.rodriguez.guriz@gmail.com
-	name = Victor Rodriguez
-	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO8svbpnhW1fbLEKhF/9ckmLS0yE1s4GdWt+SlsYb1pe

--- a/utils/00-ignore-personal-config.zsh
+++ b/utils/00-ignore-personal-config.zsh
@@ -1,0 +1,25 @@
+#!/bin/zsh
+project_path=$(realpath "$0" | sed -E 's|(/[^/]+/dotfiles)/.*|\1|')
+
+files_to_ignore=(
+	"git/.git_config/.personal/.gitconfig-local"
+	"wsl2/.config/.gpg/.gitconfig-os-specific-local"
+)
+
+current_ignored_files=()
+
+missing_ignored_files=()
+
+while IFS= read -r line; do
+	current_ignored_files+=("${line:2}")
+done < <(git -C $project_path ls-files -v | grep "^[[:lower:]]")
+
+for file_to_ignore in "${files_to_ignore[@]}"; do
+    if [[ ! " ${current_ignored_files[@]} " =~ " ${file_to_ignore#$project_path} " ]]; then
+        missing_ignored_files+=("$file_to_ignore")
+    fi
+done
+
+for file_path in "${missing_ignored_files[@]}"; do
+	git update-index --assume-unchanged "$project_path/$file_path"
+done

--- a/wsl2/.config/.gpg/.gitconfig-os-specific-local
+++ b/wsl2/.config/.gpg/.gitconfig-os-specific-local
@@ -1,0 +1,2 @@
+[gpg "ssh"]
+  program = "/mnt/c/Users/MyUser/AppData/Local/1Password/app/8/op-ssh-sign-wsl"

--- a/wsl2/.gitconfig-os-specific
+++ b/wsl2/.gitconfig-os-specific
@@ -1,4 +1,5 @@
 [core]
   sshCommand = ssh.exe
-[gpg "ssh"]
-  program = "/mnt/c/Users/victo/AppData/Local/1Password/app/8/op-ssh-sign-wsl"
+[include]
+  path = "~/.config/.gpg/.gitconfig-os-specific-local"
+  


### PR DESCRIPTION
### Problem

- There're some personal dependencies at the config:

    - old path: `git/.gitconfig` => new path: `git/.git_config/.personal/.gitconfig-local`
        - `name`
        - `email`
        - `signingkey`
        
    - old path: `wsl2/.gitconfig-os-specific` => new path: `git/.git_config/.personal/.gitconfig-os-specific-local`
        - `program`
        
- Now personal config is keeping "personal" so it's not necessary to push it to the repo. 
- This script is in charge of untrack personal files config:
`./utils/00-ignore-personal-config.zsh`
