### PR TITLE
[Feature] Add personal config v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *known_hosts*
+keys/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@
   git clone git@github.com:kucho/dotfiles.git ~/dotfiles
   ```
 
-2. Install the configuration files you need/want:
+2. Setup personal credentials:
+  ```bash
+  # Clone your personal keys files inside the dotfiles folder
+  # For more context go to the keys_template README
+  git clone git@github.com:WilberC/keys_template.git keys
+  ```
+
+3. Install the configuration files you need/want:
   ```bash
   cd ~/dotfiles
   stow zsh
@@ -18,7 +25,24 @@
   stow osx
   ```
 
-3. Edit/Replace/Create new config files and restow them:
+4. Edit/Replace/Create new config files and restow them:
   ```bash
   stow -R zsh # the folder that contains the new config file
   ```
+
+## Known issues
+
+<details>
+  <summary><b>WSL2</b></summary>
+
+
+- If you're getting `"warning: Empty last update token."` it is due to `fsmonitor` is `true` at the `git/.gitconfig` file. There is two solucions for that
+    - The not recommended one is to simple set it as `false`
+    - The second one is to upgrade the `git version` because it was solved at `2.36.1` so to upgrade it is as simple as:
+    ```bash
+    git --version # it must be >= 2.36.1
+    # if not let's upgrade git
+    sudo add-apt-repository ppa:git-core/ppa
+    sudo apt update && sudo apt upgrade -y
+    ```
+</details>

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -9,6 +9,7 @@
 [gpg]
 	format = ssh
 [include]
+	path = ~/.local_git/.git_personal_config
 	path = ~/.gitconfig-os-specific
 [init]
 	defaultBranch = main
@@ -21,7 +22,3 @@
 [rerere]
 	autoUpdate = true
 	enabled = true
-[user]
-	email = victor.rodriguez.guriz@gmail.com
-	name = Victor Rodriguez
-	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO8svbpnhW1fbLEKhF/9ckmLS0yE1s4GdWt+SlsYb1pe

--- a/linux/.ssh/config
+++ b/linux/.ssh/config
@@ -1,2 +1,4 @@
+Include ~/.local_ssh/.linux_ssh
+
 Host *
   IdentityAgent ~/.1password/agent.sock

--- a/osx/.ssh/config
+++ b/osx/.ssh/config
@@ -1,4 +1,5 @@
 Include ~/.orbstack/ssh/config
+Include ~/.local_ssh/.osx_ssh
 
 Host *
   IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"

--- a/wsl2/.gitconfig-os-specific
+++ b/wsl2/.gitconfig-os-specific
@@ -1,4 +1,5 @@
 [core]
   sshCommand = ssh.exe
-[gpg "ssh"]
-  program = "/mnt/c/Users/victo/AppData/Local/1Password/app/8/op-ssh-sign-wsl"
+[include]
+  path = "~/.local_git/.wsl2_os_specific"
+  

--- a/wsl2/.ssh/config
+++ b/wsl2/.ssh/config
@@ -1,0 +1,1 @@
+Include ~/.local_ssh/.wsl2_ssh


### PR DESCRIPTION
### Problem

- Personal info is being pushed due and it causes conflicts so now all of it is separated to [another repo](https://github.com/WilberC/keys_template)

    - old path: `git/.gitconfig`
        - `name`
        - `email`
        - `signingkey`
        
    - old path: `wsl2/.gitconfig-os-specific` 
        - `program`
        
