### PR TITLE
Use HTTPS clone URL in quick start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Quick start
 
 ```sh
-git clone git@github.com:WilberC/dotfiles.git ~/dotfiles
+git clone https://github.com/WilberC/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 bash install.sh
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@ Setup runs in two phases:
 ## Quick start
 
 ```sh
-git clone git@github.com:WilberC/dotfiles.git ~/dotfiles
+git clone https://github.com/WilberC/dotfiles.git ~/dotfiles
 cd ~/dotfiles
 bash install.sh
 ```


### PR DESCRIPTION
SSH isn't available on a fresh machine before 1Password is set up. HTTPS works without auth for a public repo, making the bootstrap experience smoother.